### PR TITLE
Compatibility issues with ConfigSpace 0.4.0

### DIFF
--- a/fanova/fanova.py
+++ b/fanova/fanova.py
@@ -78,7 +78,7 @@ class fANOVA(object):
                         raise RuntimeError('Some sample values from X are not sampled on the hypercube')
             else:
                 unique_vals = set(X[:, i])
-                if len(unique_vals) > self.cs_params[i]._num_choices:
+                if len(unique_vals) > len(self.cs_params[i].choices):
                     raise RuntimeError('There are some categoricals missing in the ConfigSpace specification')
 
         # initialize all types as 0

--- a/fanova/visualizer.py
+++ b/fanova/visualizer.py
@@ -205,7 +205,7 @@ class Visualizer(object):
         if isinstance(self.cs_params[param], (CategoricalHyperparameter)):
             param_name = self.cs_params[param].name
             labels= self.cs_params[param].choices
-            categorical_size  = self.cs_params[param]._num_choices
+            categorical_size  = len(self.cs_params[param].choices)
             marginals = [self.fanova.marginal_mean_variance_for_values([param], [i]) for i in range(categorical_size)]
             mean, v = list(zip(*marginals))
             std = np.sqrt(v)
@@ -265,7 +265,7 @@ class Visualizer(object):
         # check if categorical
         if isinstance(self.cs_params[param], (CategoricalHyperparameter)):
             labels= self.cs_params[param].choices
-            categorical_size  = self.cs_params[param]._num_choices
+            categorical_size  = len(self.cs_params[param].choices)
             mean, std = self.generate_marginal(param)
             indices = np.arange(1,categorical_size+1, 1)
             b = plt.boxplot([[x] for x in mean])
@@ -349,3 +349,4 @@ class Visualizer(object):
                 print("creating %s" % outfile_name)
                 self.plot_pairwise_marginal((param1, param2), show=False)
                 plt.savefig(outfile_name)
+


### PR DESCRIPTION
As parts of the new ConfigSpace object are written in cpython, private members are not accessible anymore. This creates the slight issue where fANOVA and the visualizer try to access _num_choices when computing/plotting categoricals. However choices is a public member and can be freely accessed.

The changes below should be merged whenever the new ConfigSpace is supposed to be supported.
PIMP already supports the new ConfigSpace and currently uses the fork from this pull request to continue to support fANOVA