### PR TITLE
FIX #87 by adding try-except for pickle-dump

### DIFF
--- a/fanova/visualizer.py
+++ b/fanova/visualizer.py
@@ -232,7 +232,12 @@ class Visualizer(object):
             if not os.path.exists(interact_dir):
                 self.logger.info('creating %s' % interact_dir)
                 os.makedirs(interact_dir)
-            pickle.dump(fig, open(interact_dir + '/%s_%s.fig.pkl' % (param_names[0], param_names[1]), 'wb'))
+            try:
+                pickle.dump(fig, open(interact_dir + '/%s_%s.fig.pkl' % (param_names[0], param_names[1]), 'wb'))
+            except AttributeError as err:
+                self.logger.debug(err, exc_info=1)
+                self.logger.info("Pickling the interactive pairwise-marginal plot (%s) raised an exception. Resume "
+                                 "without pickling. ", str(param_names))
 
         return plt
 


### PR DESCRIPTION
Catching `AttributeErrors` in pairwise marginal plots, seem to happen with statmodels 0.9 and pickling is not a crucial part of the visualization. (fix #87)