### PR TITLE
Fix issue #108 "fanova does not work with numpy >= 1.24"

### DIFF
--- a/fanova/fanova.py
+++ b/fanova/fanova.py
@@ -283,7 +283,7 @@ class fANOVA(object):
             prod_midpoints = it.product(*midpoints)
             prod_sizes = it.product(*sizes)
 
-            sample = np.full(self.n_dims, np.nan, dtype=np.float)
+            sample = np.full(self.n_dims, np.nan, dtype=np.float64)
 
             # make prediction for all midpoints and weigh them by the corresponding size
             for i, (m, s) in enumerate(zip(prod_midpoints, prod_sizes)):


### PR DESCRIPTION
Fix error where newer numpy versions have np.float deprecated that prevented fanova from workling properly