### PR TITLE
Update fanova.py

### DIFF
--- a/fanova/fanova.py
+++ b/fanova/fanova.py
@@ -283,7 +283,7 @@ class fANOVA(object):
             prod_midpoints = it.product(*midpoints)
             prod_sizes = it.product(*sizes)
 
-            sample = np.full(self.n_dims, np.nan, dtype=np.float)
+            sample = np.full(self.n_dims, np.nan, dtype=float)
 
             # make prediction for all midpoints and weigh them by the corresponding size
             for i, (m, s) in enumerate(zip(prod_midpoints, prod_sizes)):


### PR DESCRIPTION
removes deprecation warning for numpy >= 1.2.0 (and error from 2.0.0)

`np.float` is no longer supported. this fixed my errors (I have not ran tests)